### PR TITLE
Make FD closing concurrency-safe

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -441,6 +441,7 @@ static void conn_write(evutil_socket_t sockfd, short what, void *user)
 	}
 	if (c->reader.complete) {
 		close(c->sendfd);
+		c->sendfd = NS_NULL_FD;
 		start_receive(c);
 	}
 }


### PR DESCRIPTION
The daemon was closing the same FD twice causing EBADF or, in the worse scenario, closing an FD which was already allocated for another client, making client connection to either reset or hang.